### PR TITLE
Fix setting of value for isearch-project--project-dir

### DIFF
--- a/isearch-project.el
+++ b/isearch-project.el
@@ -128,7 +128,8 @@ to research from the start.")
 (defun isearch-project--prepare ()
   "Incremental search preparation."
   (let (prepare-success)
-    (setq isearch-project--project-dir (cdr (project-current)))
+    (setq isearch-project--project-dir (car (cl-remove-if-not #'stringp
+                                                              (project-current))))
     (when isearch-project--project-dir
       ;; Get the current buffer name.
       (setq isearch-project--search-path (buffer-file-name))


### PR DESCRIPTION
At least in my setup (Emacs 28.2, project.el 0.9.8), the return value for `(project-current)` is a list of three elements (for exaple `(vc Git "~/.emacs.d/")`).

As it currently is, isearch-project--prepare` sets the value of `isearch-project--project-dir` as the cdr of `(project-current)`, which obviously doesn't work in my case.

This fix should be robust enough, assuming that the only string ever in the value of `(project-current)` is in fact the path of the project directory.